### PR TITLE
added bill pagination

### DIFF
--- a/app/api/bills/[location]/route.ts
+++ b/app/api/bills/[location]/route.ts
@@ -1,30 +1,31 @@
 // app/api/bills/[location].ts
-import { NextResponse } from 'next/server';
-import transformData from '@/utilities/transformMasterList';
 
-export async function GET(request: Request, context: any) {
-    const { params } = context
-    const location = params?.location
+// import { NextResponse } from 'next/server';
+// import transformData from '@/utilities/transformMasterList';
 
-    const year = new Date().getFullYear(); // Getting the current year
+// export async function GET(request: Request, context: any) {
+//     const { params } = context
+//     const location = params?.location
 
-    if (!location) {
-        return NextResponse.json({ error: 'Location parameter is required' }, { status: 400 });
-    }
+//     const year = new Date().getFullYear(); // Getting the current year
 
-    try {
-        const legiscanApiKey = process.env.LEGI_KEY; // Your LegiScan API key
+//     if (!location) {
+//         return NextResponse.json({ error: 'Location parameter is required' }, { status: 400 });
+//     }
 
-        const response = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getMasterList&state=${location}&year=${year}`);
-        const data = await response.json();
+//     try {
+//         const legiscanApiKey = process.env.LEGI_KEY; // Your LegiScan API key
 
-        const transformedData = transformData(data);
-        return NextResponse.json({
-            count: transformedData.length,
-            transformedData
-        });
-    } catch (error) {
-        console.error(error);
-        return NextResponse.json({ error: 'Error fetching data from LegiScan' }, { status: 500 });
-    }
-}
+//         const response = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getMasterList&state=${location}&year=${year}`);
+//         const data = await response.json();
+
+//         const transformedData = transformData(data);
+//         return NextResponse.json({
+//             count: transformedData.length,
+//             transformedData
+//         });
+//     } catch (error) {
+//         console.error(error);
+//         return NextResponse.json({ error: 'Error fetching data from LegiScan' }, { status: 500 });
+//     }
+// }

--- a/app/api/bills/[location]/route.ts
+++ b/app/api/bills/[location]/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: Request, context: any) {
 
         const response = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getMasterList&state=${location}&year=${year}`);
         const data = await response.json();
-      
+
         const transformedData = transformData(data);
         return NextResponse.json({
             count: transformedData.length,

--- a/app/state/[state]/session/[session]/layout.tsx
+++ b/app/state/[state]/session/[session]/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import Loading from './loading';
 import Session from '@/data/sessions';
-import SessionPeopleResponse from '@/data/SessionPeopleResponse';
+import SessionPeopleResponse from '@/data/sessionPeopleResponse';
 
 async function getSessionData(sessionID: number): Promise<any> {
   try {

--- a/app/state/[state]/session/[session]/layout.tsx
+++ b/app/state/[state]/session/[session]/layout.tsx
@@ -1,0 +1,49 @@
+import { Suspense } from 'react';
+import Loading from './loading';
+import Session from '@/data/sessions';
+import SessionPeopleResponse from '@/data/SessionPeopleResponse';
+
+async function getSessionData(sessionID: number): Promise<any> {
+  try {
+    const legiscanApiKey = process.env.LEGI_KEY;
+    const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSessionPeople&id=${sessionID}`);
+    const data = await res.json();
+    return data;
+
+  } catch (error) {
+    console.error(error);
+    return []; // Return an empty array in case of error
+  }
+}
+
+export default async function SessionBillsLayout({
+  children,
+  params
+}: {
+  children: React.ReactNode,
+  params: { session: number; state: string }
+}) {
+
+  const sessionData: SessionPeopleResponse = await getSessionData(params.session)
+  const session: Session = sessionData.sessionpeople.session
+
+  return (
+    <>
+
+      <div className="border rounded-lg p-4 shadow-sm bg-gray-900 text-gray-200 transition-colors">
+        <h2 className="text-lg font-semibold">{session.session_title}</h2>
+        <p><strong>Session Name:</strong> {session.session_name}</p>
+        <p><strong>Years:</strong> {session.year_start} - {session.year_end}</p>
+        <p><strong>Session Tag:</strong> {session.session_tag}</p>
+        <p><strong>Special Session:</strong> {session.special ? 'Yes' : 'No'}</p>
+        <p><strong>Prefile:</strong> {session.prefile ? 'Yes' : 'No'}</p>
+        <p><strong>Sine Die:</strong> {session.sine_die ? 'Yes' : 'No'}</p>
+        <p><strong>Prior:</strong> {session.prior ? 'Yes' : 'No'}</p>
+      </div>
+
+      <div className='p-4 bg-gray-200 min-h-screen'>
+        <Suspense fallback={<Loading />}>{children}</Suspense>
+      </div>
+    </>
+  )
+}

--- a/app/state/[state]/session/[session]/page.tsx
+++ b/app/state/[state]/session/[session]/page.tsx
@@ -1,63 +1,49 @@
 import { NextResponse } from 'next/server';
-import transformData from "@/utilities/transformMasterList";
-import Bill from '@/data/bills';
+// import transformData from "@/utilities/transformMasterList";
+import transformData from "@/utilities/transformSearchResult";
+import getSearchBill from '@/data/getSearchBill';
+import Summary from '@/data/sessionSummary';
 import PaginationControls from './paginationControls';
 
-const getPage = (pageSize: number, page: number, list: any[]) => {
-    const start = (page - 1) * pageSize;
-    const end = start + pageSize;
-    return list.slice(start, end);
-};
+async function getSessionBills(sessionID: number, page: number): Promise<{ bills: getSearchBill[], summary: Summary }> {
 
-async function getSessionBills(sessionID: number): Promise<Bill[]> {
     try {
         const legiscanApiKey = process.env.LEGI_KEY;
-        const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getMasterList&id=${sessionID}`);
+        const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSearch&id=${sessionID}&page=${page}`);
         const data = await res.json();
 
         const transformedData = transformData(data);
         return transformedData; // Return the transformed data directly
+
     } catch (error) {
         console.error(error);
-        return []; // Return an empty array in case of error
+        return { bills: [], summary: {} as Summary }; // Return empty data in case of error
     }
 }
 
 
-export default async function Page({ params, searchParams }: { params: { session: number; state: string }, searchParams: { page: string } }) {
-    const currentPage = parseInt(searchParams.page || '1', 10);
-    const pageSize = 48;
 
-    const billList: any = await getSessionBills(params.session)
-    const session = billList.pop()
-    const totalCount = billList.length;
-    const totalPages = Math.ceil(totalCount / pageSize);
-    const currentBills = getPage(pageSize, currentPage, billList);
+export default async function Page({ params, searchParams }: { params: { session: number }, searchParams: { page: string } }) {
+
+    const currentPage = parseInt(searchParams.page || '1', 10);
+    const { bills, summary } = await getSessionBills(params.session, currentPage)
 
     return (
         <>
-            <div className="border rounded-lg p-4 shadow-sm bg-gray-900 text-gray-200 transition-colors">
-                <h2 className="text-lg font-semibold">{session.session_title}</h2>
-                <p><strong>Session Name:</strong> {session.session_name}</p>
-                <p><strong>Years:</strong> {session.year_start} - {session.year_end}</p>
-                <p><strong>Session Tag:</strong> {session.session_tag}</p>
-                <p><strong>Special Session:</strong> {session.special ? 'Yes' : 'No'}</p>
-                <p><strong>Prefile:</strong> {session.prefile ? 'Yes' : 'No'}</p>
-                <p><strong>Sine Die:</strong> {session.sine_die ? 'Yes' : 'No'}</p>
-                <p><strong>Prior:</strong> {session.prior ? 'Yes' : 'No'}</p>
-            </div>
+
             <ul role="list" className="mt-3 grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
-                {currentBills.map((bill: Bill) => (
+                {bills.map((bill: getSearchBill) => (
                     <li key={bill.bill_id} className="py-4">
                         <div className="border rounded-lg p-4 shadow-sm bg-white">
                             <div className="border-b min-h-[4.5em] border-gray-200 py-2">
                                 <h3 className="line-clamp-2 text-base font-semibold leading-6 text-gray-900">{bill.title}</h3>
                             </div>
-                            <p className='line-clamp-1'><strong>Bill Number:</strong> {bill.number}</p>
+                            <p className='line-clamp-1'><strong>Bill Number:</strong> {bill.bill_number}</p>
                             <p className='line-clamp-1'><strong>Last Action:</strong> {bill.last_action}</p>
                             <p className='line-clamp-1'><strong>Last Action Date:</strong> {bill.last_action_date}</p>
-                            <p className='line-clamp-1'><strong>Status Date:</strong> {bill.status_date}</p>
-                            <p className="line-clamp-2 min-h-[3em]">{bill.description}</p> {/* Updated line */}
+                            {/* <p className='line-clamp-1'><strong>Status Date:</strong> {bill.status_date}</p> */}
+                            {/* <p className="line-clamp-2 min-h-[3em]">{bill.description}</p>  */}
+                            {/* description and status date not accessible from getSearch */}
                             <div className="mt-6 border-t border-gray-900/5 px-3 py-3">
                                 <a className="text-sm font-semibold leading-6 text-gray-900" href={bill.url} target="_blank" rel="noopener noreferrer">View Bill <span aria-hidden="true">&rarr;</span></a>
                             </div>
@@ -65,7 +51,7 @@ export default async function Page({ params, searchParams }: { params: { session
                     </li>
                 ))}
             </ul>
-            <PaginationControls currentPage={currentPage} totalPages={totalPages} />
+            <PaginationControls currentPage={currentPage} totalPages={summary.page_total} />
         </>
     )
 }

--- a/app/state/[state]/session/[session]/page.tsx
+++ b/app/state/[state]/session/[session]/page.tsx
@@ -1,13 +1,20 @@
 import { NextResponse } from 'next/server';
 import transformData from "@/utilities/transformMasterList";
 import Bill from '@/data/bills';
+import PaginationControls from './paginationControls';
+
+const getPage = (pageSize: number, page: number, list: any[]) => {
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return list.slice(start, end);
+};
 
 async function getSessionBills(sessionID: number): Promise<Bill[]> {
     try {
-        const legiscanApiKey = process.env.LEGI_KEY; 
+        const legiscanApiKey = process.env.LEGI_KEY;
         const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getMasterList&id=${sessionID}`);
         const data = await res.json();
-    
+
         const transformedData = transformData(data);
         return transformedData; // Return the transformed data directly
     } catch (error) {
@@ -17,10 +24,17 @@ async function getSessionBills(sessionID: number): Promise<Bill[]> {
 }
 
 
-export default async function Page({ params }: { params: { session: number, state: string } }) {
+export default async function Page({ params, searchParams }: { params: { session: number; state: string }, searchParams: { page: string } }) {
+    const currentPage = parseInt(searchParams.page || '1', 10);
+    const pageSize = 48;
+
     const billList: any = await getSessionBills(params.session)
     const session = billList.pop()
-    return(
+    const totalCount = billList.length;
+    const totalPages = Math.ceil(totalCount / pageSize);
+    const currentBills = getPage(pageSize, currentPage, billList);
+
+    return (
         <>
             <div className="border rounded-lg p-4 shadow-sm bg-gray-900 text-gray-200 transition-colors">
                 <h2 className="text-lg font-semibold">{session.session_title}</h2>
@@ -31,26 +45,27 @@ export default async function Page({ params }: { params: { session: number, stat
                 <p><strong>Prefile:</strong> {session.prefile ? 'Yes' : 'No'}</p>
                 <p><strong>Sine Die:</strong> {session.sine_die ? 'Yes' : 'No'}</p>
                 <p><strong>Prior:</strong> {session.prior ? 'Yes' : 'No'}</p>
-              </div>
+            </div>
             <ul role="list" className="mt-3 grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
-                {billList.map((bill: Bill) => (
-                <li key={bill.bill_id} className="py-4">
-                    <div className="border rounded-lg p-4 shadow-sm bg-white">
-                        <div className="border-b min-h-[4.5em] border-gray-200 py-2">
-                            <h3 className="line-clamp-2 text-base font-semibold leading-6 text-gray-900">{bill.title}</h3>
+                {currentBills.map((bill: Bill) => (
+                    <li key={bill.bill_id} className="py-4">
+                        <div className="border rounded-lg p-4 shadow-sm bg-white">
+                            <div className="border-b min-h-[4.5em] border-gray-200 py-2">
+                                <h3 className="line-clamp-2 text-base font-semibold leading-6 text-gray-900">{bill.title}</h3>
+                            </div>
+                            <p className='line-clamp-1'><strong>Bill Number:</strong> {bill.number}</p>
+                            <p className='line-clamp-1'><strong>Last Action:</strong> {bill.last_action}</p>
+                            <p className='line-clamp-1'><strong>Last Action Date:</strong> {bill.last_action_date}</p>
+                            <p className='line-clamp-1'><strong>Status Date:</strong> {bill.status_date}</p>
+                            <p className="line-clamp-2 min-h-[3em]">{bill.description}</p> {/* Updated line */}
+                            <div className="mt-6 border-t border-gray-900/5 px-3 py-3">
+                                <a className="text-sm font-semibold leading-6 text-gray-900" href={bill.url} target="_blank" rel="noopener noreferrer">View Bill <span aria-hidden="true">&rarr;</span></a>
+                            </div>
                         </div>
-                        <p className='line-clamp-1'><strong>Bill Number:</strong> {bill.number}</p>
-                        <p className='line-clamp-1'><strong>Last Action:</strong> {bill.last_action}</p>
-                        <p className='line-clamp-1'><strong>Last Action Date:</strong> {bill.last_action_date}</p>
-                        <p className='line-clamp-1'><strong>Status Date:</strong> {bill.status_date}</p>
-                        <p className="line-clamp-2 min-h-[3em]">{bill.description}</p> {/* Updated line */}
-                        <div className="mt-6 border-t border-gray-900/5 px-3 py-3">
-                            <a  className="text-sm font-semibold leading-6 text-gray-900" href={bill.url} target="_blank" rel="noopener noreferrer">View Bill <span aria-hidden="true">&rarr;</span></a>
-                        </div>
-                    </div>
-                </li>
+                    </li>
                 ))}
             </ul>
+            <PaginationControls currentPage={currentPage} totalPages={totalPages} />
         </>
     )
 }

--- a/app/state/[state]/session/[session]/paginationControls.tsx
+++ b/app/state/[state]/session/[session]/paginationControls.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import PaginationControlsProps from '@/data/paginationControlsProps';
 
 const PaginationControls: FC<PaginationControlsProps> = ({ currentPage, totalPages }) => {
+
   return (
     <div className="pagination-controls flex justify-center items-center mt-10 mb-10 space-x-12">
       <Link href={`?page=${currentPage - 1}`}>

--- a/app/state/[state]/session/[session]/paginationControls.tsx
+++ b/app/state/[state]/session/[session]/paginationControls.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react'
+import Link from 'next/link';
+import PaginationControlsProps from '@/data/paginationControlsProps';
+
+const PaginationControls: FC<PaginationControlsProps> = ({ currentPage, totalPages }) => {
+  return (
+    <div className="pagination-controls flex justify-center items-center mt-10 mb-10 space-x-12">
+      <Link href={`?page=${currentPage - 1}`}>
+        <button
+          disabled={currentPage === 1}
+          className={`px-4 py-2 rounded-md transition-colors ${currentPage === 1
+            ? 'hidden'
+            : 'bg-gray-900 text-gray-200 hover:bg-gray-400 hover:text-black'
+            }`}
+        >
+          Previous
+        </button>
+      </Link>
+      <span>Page {currentPage} of {totalPages}</span>
+      <Link href={`?page=${currentPage + 1}`}>
+        <button
+          disabled={currentPage === totalPages}
+          className={`px-4 py-2 rounded-md transition-colors ${currentPage === totalPages
+            ? 'hidden'
+            : 'bg-gray-900 text-gray-200 hover:bg-gray-400 hover:text-black'
+            }`}
+        >
+          Next
+        </button>
+      </Link>
+    </div>
+  );
+};
+
+export default PaginationControls;

--- a/data/People.ts
+++ b/data/People.ts
@@ -1,0 +1,25 @@
+export default interface Person {
+  people_id: number;
+  person_hash: string;
+  party_id: string;
+  state_id: number;
+  party: string;
+  role_id: number;
+  role: string;
+  name: string;
+  first_name: string;
+  middle_name: string;
+  last_name: string;
+  suffix: string;
+  nickname: string;
+  district: string;
+  ftm_eid: number;
+  votesmart_id: number;
+  opensecrets_id: string;
+  knowwho_pid: number;
+  ballotpedia: string;
+  bioguide_id: string;
+  committee_sponsor: number;
+  committee_id: number;
+  state_federal: number;
+}

--- a/data/SessionPeopleResponse.ts
+++ b/data/SessionPeopleResponse.ts
@@ -1,0 +1,11 @@
+import Session from "./sessions";
+import Person from "./People";
+
+export default interface SessionPeopleResponse {
+  status: string;
+  sessionpeople: {
+    session: Session;
+    people: Person[];
+  };
+}
+

--- a/data/SessionPeopleResponse.ts
+++ b/data/SessionPeopleResponse.ts
@@ -1,5 +1,5 @@
 import Session from "./sessions";
-import Person from "./People";
+import Person from "./people";
 
 export default interface SessionPeopleResponse {
   status: string;

--- a/data/apiResponse.ts
+++ b/data/apiResponse.ts
@@ -1,6 +1,12 @@
-import MasterList from "./masterList";
+// import MasterList from "./masterList";
+
+// export default interface ApiResponse {
+//     status: string;
+//     masterlist: MasterList;
+// }
+import SearchResult from "./searchResult";
 
 export default interface ApiResponse {
     status: string;
-    masterlist: MasterList;
+    searchresult: SearchResult;
 }

--- a/data/getSearchBill.ts
+++ b/data/getSearchBill.ts
@@ -1,0 +1,13 @@
+export default interface getSearchBill {
+  relevance: number;
+  state: string;
+  bill_number: string;
+  bill_id: number;
+  change_hash: string;
+  url: string;
+  text_url: string;
+  research_url: string;
+  last_action_date: string;
+  last_action: string;
+  title: string;
+}

--- a/data/paginationControlsProps.ts
+++ b/data/paginationControlsProps.ts
@@ -1,0 +1,4 @@
+export default interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+}

--- a/data/searchResult.ts
+++ b/data/searchResult.ts
@@ -1,0 +1,7 @@
+import getSearchBill from "./getSearchBill";
+import Summary from "./sessionSummary";
+
+export default interface SearchResult {
+  summary: Summary;
+  [key: string]: getSearchBill | Summary;
+}

--- a/data/sessionSummary.ts
+++ b/data/sessionSummary.ts
@@ -1,0 +1,9 @@
+export default interface Summary {
+  page: string;
+  range: string;
+  relevancy: string;
+  count: number;
+  page_current: string;
+  page_total: number;
+  query: string;
+}

--- a/utilities/transformMasterList.ts
+++ b/utilities/transformMasterList.ts
@@ -1,15 +1,15 @@
-import ApiResponse from "@/data/apiResponse";
-import Bill from "@/data/bills";
+// import ApiResponse from "@/data/apiResponse";
+// import Bill from "@/data/bills";
 
-export default function transformData(data: ApiResponse): Bill[] {
-    const masterlist = data.masterlist;
-    let billsArray: Bill[] = [];
+// export default function transformData(data: ApiResponse): Bill[] {
+//     const masterlist = data.masterlist;
+//     let billsArray: Bill[] = [];
 
-    for (let key in masterlist) {
-        if (masterlist.hasOwnProperty(key)) {
-            billsArray.push(masterlist[key]);
-        }
-    }
+//     for (let key in masterlist) {
+//         if (masterlist.hasOwnProperty(key)) {
+//             billsArray.push(masterlist[key]);
+//         }
+//     }
 
-    return billsArray;
-}
+//     return billsArray;
+// }

--- a/utilities/transformSearchResult.ts
+++ b/utilities/transformSearchResult.ts
@@ -1,0 +1,22 @@
+import ApiResponse from "@/data/apiResponse";
+import getSearchBill from "@/data/getSearchBill";
+import Summary from "@/data/sessionSummary";
+
+interface TransformedData {
+  bills: getSearchBill[];
+  summary: Summary;
+}
+
+export default function transformData(data: ApiResponse): TransformedData {
+  const searchresult = data.searchresult;
+  const summary = searchresult.summary as Summary;
+  let billsArray: getSearchBill[] = [];
+
+  for (let key in searchresult) {
+    if (searchresult.hasOwnProperty(key) && !isNaN(Number(key))) {
+      billsArray.push(searchresult[key] as getSearchBill);
+    }
+  }
+
+  return { bills: billsArray, summary };
+}


### PR DESCRIPTION
**Issue**
-Paginate Session Bills

**Solution**
-Manually paginate data from getMasterList and implement it using search params

**Implementation Details**
-I created a getPage function to sort through the data by pages. On the Bills page I get the current page from the search params and set the page length as well as getting total pages. Using the getPage function I create a billList for the currentPage. I created a component PaginationControls as well as PaginationControlsProps for the types. Pagination Controls has the next and prev buttons which are hidden if they can't go further. It displays the currentPage and totalPages passed down through the bills page.

**Testing**
-You can go to a Session Bills page and scroll to the bottom. There are 48 per page to fit our width of bills and on the first page the prev button will be hidden. After clicking Next it will show you the next page of bills. On the last page the next button will be hidden.

**Additional Information**
-There is a getSearch method for session bills that has pagination but it doesn't include session data and the session data should be shown at the top of the session bills page. I don't know if it's possible to send the session data down through the link from the sessions page. So on the session bills page rather than using both getSearch for the bill pagination and getMasterList just for data on a single session, I paginated the session bills manually.
