### PR TITLE
added sponsor page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FC, useEffect, useState } from 'react';
-import SaveButton from '../state/[state]/session/[session]/bill/[bill]/saveButton';
+import SaveButton from '../state/[state]/session/[session]/bill/[bill]/billSaveButton';
 import Link from 'next/link';
 
 const SavedBillsPage: FC = () => {

--- a/app/state/[state]/session/[session]/bill/[bill]/billSaveButton.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/billSaveButton.tsx
@@ -3,7 +3,7 @@
 import { FC, useState, useEffect } from 'react';
 import SaveButtonProps from '@/data/saveButtonProps';
 
-const SaveButton: FC<SaveButtonProps> = ({ bill }) => {
+const billSaveButton: FC<SaveButtonProps> = ({ bill }) => {
   const [isSaved, setIsSaved] = useState(false);
   const [savedBillId, setSavedBillId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
@@ -64,7 +64,6 @@ const SaveButton: FC<SaveButtonProps> = ({ bill }) => {
         }
       } else {
         // If the bill is not saved, save it
-        console.log('bill', bill)
         const response = await fetch('/api/saveBill', {
           method: 'POST',
           headers: {
@@ -108,4 +107,4 @@ const SaveButton: FC<SaveButtonProps> = ({ bill }) => {
   );
 };
 
-export default SaveButton;
+export default billSaveButton;

--- a/app/state/[state]/session/[session]/bill/[bill]/layout.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import SaveButton from "./saveButton";
+import SaveButton from "./billSaveButton";
 
 async function getBillData(billId: number): Promise<any> {
   try {

--- a/app/state/[state]/session/[session]/bill/[bill]/sponsors/page.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/sponsors/page.tsx
@@ -47,9 +47,14 @@ export default async function Page({
               <div className="border rounded-lg p-4 shadow-sm bg-white">
                 <p className='line-clamp-1'><strong>{sponsor.role}. {sponsor.name} ({sponsor.party})</strong></p>
                 <p className='line-clamp-1'><strong>District:</strong> {sponsor.district}</p>
-                <p className=" font-semibold leading-6 text-blue-600">
-                  Save <span aria-hidden="true">☆</span>
-                </p>
+                <div className="flex space-x-10 my-4">
+                  <p className=" font-semibold leading-6 text-blue-600">
+                    Save <span aria-hidden="true">☆</span>
+                  </p>
+                  <Link href={`/state/${params.state}/sponsor/${sponsor.people_id}/bills`}>
+                    <p className="text-blue-600 cursor-pointer font-semibold"> View Sponsor <span aria-hidden="true">&rarr;</span></p>
+                  </Link>
+                </div>
               </div>
             </li>
           ))

--- a/app/state/[state]/sponsor/[sponsor]/bills/page.tsx
+++ b/app/state/[state]/sponsor/[sponsor]/bills/page.tsx
@@ -1,0 +1,82 @@
+import getSearchBill from "@/data/getSearchBill";
+import Link from "next/link";
+
+async function getSponsorData(peopleId: number): Promise<any> {
+  try {
+    const legiscanApiKey = process.env.LEGI_KEY;
+    const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSponsoredList&id=${peopleId}`);
+    const data = await res.json();
+
+    return data;
+
+  } catch (error) {
+    console.error(error);
+    return []; // Return an empty array in case of error
+  }
+}
+
+async function getBillData(billId: number): Promise<any> {
+  try {
+    const legiscanApiKey = process.env.LEGI_KEY;
+    const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getBill&id=${billId}`);
+    const data = await res.json();
+
+    return data;
+
+  } catch (error) {
+    console.error(error);
+    return []; // Return an empty array in case of error
+  }
+}
+
+
+export default async function Page({
+  params
+}: {
+  params: { state: string, sponsor: string }
+}) {
+
+  const sponsorData = await getSponsorData(Number(params.sponsor))
+  const sponsor = sponsorData.sponsoredbills.sponsor
+  const bills = sponsorData.sponsoredbills.bills
+
+  const detailedBills = await Promise.all(
+    bills.map(async (bill: any) => {
+      const billData = await getBillData(bill.bill_id);
+      return { ...billData.bill };
+    })
+  );
+
+  return (
+    <>
+      <div className="flex justify-center space-x-12 mb-10 text-lg">
+        <Link href={`/state/${params.state}/sponsor/${sponsor.people_id}/bills`}>
+          <p className=" cursor-pointer text-blue-600 underline font-semibold">Bills</p>
+        </Link>
+        <Link href={`/state/${params.state}/sponsor/${sponsor.people_id}/sessions`}>
+          <p className=" font-semibold cursor-pointer">Sessions</p>
+        </Link>
+      </div>
+
+      <ul role="list" className="mt-3 max-w-4xl mx-auto">
+        {bills.length > 0 ? (
+          detailedBills.map((bill: getSearchBill) => (
+            <li key={bill.bill_id} className="w-full my-4">
+              <div className="border rounded-lg p-4 shadow-sm bg-white">
+                <p className='line-clamp-1'><strong>{bill.title}</strong></p>
+                <p className='line-clamp-1'>{bill.description}</p>
+                <Link href={`/state/${params.state}/session/${bill.session.session_id}/bill/${bill.bill_id}/history`}>
+                  <p className="text-sm font-semibold leading-6 text-blue-600" >
+                    View Bill
+                    <span aria-hidden="true">&rarr;</span></p>
+                </Link>
+              </div>
+            </li>
+          ))
+        ) : (
+          <li className="border rounded-lg p-4 shadow-sm bg-white">No bills.</li>
+        )}
+      </ul>
+    </>
+  )
+}

--- a/app/state/[state]/sponsor/[sponsor]/layout.tsx
+++ b/app/state/[state]/sponsor/[sponsor]/layout.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+async function getSponsorData(peopleId: number): Promise<any> {
+  try {
+    const legiscanApiKey = process.env.LEGI_KEY;
+    const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSponsoredList&id=${peopleId}`);
+    const data = await res.json();
+
+    return data;
+
+  } catch (error) {
+    console.error(error);
+    return []; // Return an empty array in case of error
+  }
+}
+
+export default async function SponsorLayout({
+  children,
+  params
+}: {
+  children: React.ReactNode
+  params: { state: string, sponsor: string }
+}) {
+
+  const sponsorData = await getSponsorData(Number(params.sponsor))
+  const sponsor = sponsorData.sponsoredbills.sponsor
+
+  return (
+    <>
+      <div className="border rounded-lg p-4 shadow-sm ">
+        <p className="font-bold text-xl mb-2">{`${sponsor.role}. ${sponsor.name} (${sponsor.party})`}</p>
+        <p><strong>State:</strong> {params.state}</p>
+        <p> <strong>District:</strong> {sponsor.district} </p>
+        <p className=" font-semibold leading-6 text-blue-600">
+          Save <span aria-hidden="true">☆</span>
+        </p>
+      </div>
+
+      <div className='p-4 bg-gray-200 min-h-screen'>
+        {children}
+      </div>
+    </>
+  )
+}

--- a/app/state/[state]/sponsor/[sponsor]/page.tsx
+++ b/app/state/[state]/sponsor/[sponsor]/page.tsx
@@ -1,0 +1,6 @@
+export default function Page() {
+
+  return (
+    <></>
+  )
+}

--- a/app/state/[state]/sponsor/[sponsor]/sessions/page.tsx
+++ b/app/state/[state]/sponsor/[sponsor]/sessions/page.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import Session from "@/data/sessions";
+
+async function getSponsorData(peopleId: number): Promise<any> {
+  try {
+    const legiscanApiKey = process.env.LEGI_KEY;
+    const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSponsoredList&id=${peopleId}`);
+    const data = await res.json();
+
+    return data;
+
+  } catch (error) {
+    console.error(error);
+    return []; // Return an empty array in case of error
+  }
+}
+
+async function getSessionData(sessionId: number): Promise<any> {
+  try {
+    const legiscanApiKey = process.env.LEGI_KEY;
+    const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getBill&id=${sessionId}`);
+    const data = await res.json();
+
+    return data;
+
+  } catch (error) {
+    console.error(error);
+    return []; // Return an empty array in case of error
+  }
+}
+
+
+export default async function Page({
+  params
+}: {
+  params: { state: string, sponsor: string }
+}) {
+
+  const sponsorData = await getSponsorData(Number(params.sponsor))
+  const sponsor = sponsorData.sponsoredbills.sponsor
+  const sessions = sponsorData.sponsoredbills.sessions
+
+  return (
+    <>
+      <div className="flex justify-center space-x-12 mb-10 text-lg">
+        <Link href={`/state/${params.state}/sponsor/${sponsor.people_id}/bills`}>
+          <p className=" cursor-pointer  font-semibold">Bills</p>
+        </Link>
+        <Link href={`/state/${params.state}/sponsor/${sponsor.people_id}/sessions`}>
+          <p className=" font-semibold text-blue-600 underline cursor-pointer">Sessions</p>
+        </Link>
+      </div>
+
+      <ul role="list" className="mt-3 max-w-4xl mx-auto">
+        {sessions.length > 0 ? (
+          sessions.map((session: Session) => (
+            <li key={session.session_id} className="w-full my-4">
+              <div className="border rounded-lg p-4 shadow-sm bg-white">
+                <p className='line-clamp-1'><strong>{params.state} {session.session_name}</strong></p>
+                <Link href={`/state/${params.state}/session/${session.session_id}`}>
+                  <p className="text-sm font-semibold leading-6 text-blue-600" >
+                    View Session
+                    <span aria-hidden="true">&rarr;</span></p>
+                </Link>
+              </div>
+            </li>
+          ))
+        ) : (
+          <li className="border rounded-lg p-4 shadow-sm bg-white">No sessions.</li>
+        )}
+      </ul>
+    </>
+  )
+}

--- a/data/getSearchBill.ts
+++ b/data/getSearchBill.ts
@@ -10,4 +10,9 @@ export default interface getSearchBill {
   last_action_date: string;
   last_action: string;
   title: string;
+  description: string;
+  session: {
+    session_title: string;
+    session_id: number;
+  };
 }


### PR DESCRIPTION
**Issue**
Create page to show sponsors and their bills/sessions

**Solution/Implementation Details**
Created new sponsor folder within state folder with a layout showing the sponsor info. Created a nav to go between the bills they sponsored and their sessions with links for each individual bill/session.

**Testing**
Go to an individual bill page, sponsors tab, and click link view sponsor. Can view their bills and sessions and click the link for the individual bills/sessions.

**Additional Information**
The sponsor page loads a bit slowly because there are a lot of bills for some of them. I couldn't find any way to paginate it through the api in the docs. At the very least, should probably show loading while waiting because right now clicking on view sponsor takes some time.

It seems like some links are not working (for routes already established). After messing around with it, I think the ones working are only working because they are cached for me. I tried making requests to postman and I think the problem is this:
{
    "status": "ERROR",
    "alert": {
        "message": "API key has exceeded maximum query count for the current 30-day period (30,198 of 30,000)",
        "contact": {
            "email": "api@legiscan.com",
            "phone": "800-618-2750"
        }
    }
}
