### PR TITLE
error boundaries and fetch logs

### DIFF
--- a/app/state/[state]/page.tsx
+++ b/app/state/[state]/page.tsx
@@ -3,6 +3,14 @@ import Link from "next/link";
 
 async function getSessionList(stateAbbreviation: string) {
   const legiscanApiKey = process.env.LEGI_KEY;
+
+  if (!stateAbbreviation || typeof stateAbbreviation !== 'string') {
+    console.error('Invalid state abbreviation');
+    throw new Error('Invalid state abbreviation');
+  }
+
+  console.log('Fetching data');
+
   const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSessionList&state=${stateAbbreviation}`);
   const data = await res.json();
 

--- a/app/state/[state]/session/[session]/bill/[bill]/history/page.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/history/page.tsx
@@ -3,6 +3,13 @@ import Link from "next/link";
 
 async function getBillData(billId: number): Promise<any> {
   try {
+    if (!billId || typeof billId !== 'number') {
+      console.error('Invalid bill id');
+      throw new Error('Invalid bill id');
+    }
+
+    console.log('Fetching data');
+
     const legiscanApiKey = process.env.LEGI_KEY;
     const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getBill&id=${billId}`);
     const data = await res.json();

--- a/app/state/[state]/session/[session]/bill/[bill]/layout.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/layout.tsx
@@ -3,6 +3,13 @@ import BillSaveButton from "./BillSaveButton";
 
 async function getBillData(billId: number): Promise<any> {
   try {
+    if (!billId || typeof billId !== 'number') {
+      console.error('Invalid bill id');
+      throw new Error('Invalid bill id');
+    }
+
+    console.log('Fetching data');
+
     const legiscanApiKey = process.env.LEGI_KEY;
     const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getBill&id=${billId}`);
     const data = await res.json();

--- a/app/state/[state]/session/[session]/bill/[bill]/sponsors/page.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/sponsors/page.tsx
@@ -3,6 +3,13 @@ import Link from "next/link";
 
 async function getBillData(billId: number): Promise<any> {
   try {
+    if (!billId || typeof billId !== 'number') {
+      console.error('Invalid bill id');
+      throw new Error('Invalid bill id');
+    }
+
+    console.log('Fetching data');
+
     const legiscanApiKey = process.env.LEGI_KEY;
     const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getBill&id=${billId}`);
     const data = await res.json();

--- a/app/state/[state]/session/[session]/bill/[bill]/votes/page.tsx
+++ b/app/state/[state]/session/[session]/bill/[bill]/votes/page.tsx
@@ -3,6 +3,13 @@ import Link from "next/link";
 
 async function getBillData(billId: number): Promise<any> {
   try {
+    if (!billId || typeof billId !== 'number') {
+      console.error('Invalid bill id');
+      throw new Error('Invalid bill id');
+    }
+
+    console.log('Fetching data');
+
     const legiscanApiKey = process.env.LEGI_KEY;
     const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getBill&id=${billId}`);
     const data = await res.json();

--- a/app/state/[state]/session/[session]/page.tsx
+++ b/app/state/[state]/session/[session]/page.tsx
@@ -6,7 +6,14 @@ import SessionBills from './sessionBills';
 
 async function getSessionData(sessionID: number): Promise<any> {
   try {
-    console.log("Pre Fetching data: ", sessionID)
+    if (!sessionID || typeof sessionID !== 'number') {
+      console.error('Invalid session id');
+      throw new Error('Invalid session id');
+    }
+
+    console.log('Fetching data');
+
+
     const legiscanApiKey = process.env.LEGI_KEY;
     const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSessionPeople&id=${sessionID}`);
     const data = await res.json();

--- a/app/state/[state]/session/[session]/sessionBills.tsx
+++ b/app/state/[state]/session/[session]/sessionBills.tsx
@@ -7,6 +7,18 @@ import Link from "next/link";
 async function getSessionBills(sessionID: number, page: number): Promise<{ bills: getSearchBill[], summary: Summary }> {
 
     try {
+        if (!sessionID || typeof sessionID !== 'number') {
+            console.error('Invalid session id');
+            throw new Error('Invalid session id');
+        }
+
+        if (!page || typeof page !== 'number') {
+            console.error('Invalid page');
+            throw new Error('Invalid page');
+        }
+
+        console.log('Fetching data');
+
         const legiscanApiKey = process.env.LEGI_KEY;
         const res = await fetch(`https://api.legiscan.com/?key=${legiscanApiKey}&op=getSearch&id=${sessionID}&page=${page}`);
         const data = await res.json();


### PR DESCRIPTION
added error boundaries for params and console logs for all fetch calls to legiscan